### PR TITLE
explicitly activate base

### DIFF
--- a/bin/activate_gpu_env
+++ b/bin/activate_gpu_env
@@ -25,7 +25,7 @@ ENV_NAME="${ENV_NAME}_$ARCH_NAME"
 
 # go to base env and derive the python executable of $ENV_NAME from it
 # (source activate $ENV_NAME && PY=$(which python) is not 100% reliable, because it sometimes picks up the base env's python)
-source activate
+source activate base
 
 PY=$(which python)
 PY=$(dirname $(dirname ${PY}))


### PR DESCRIPTION
avoids a weird bug where conda activate attempts to activate <env_name> ('lala' in the example below)
(without the  <arch name>) (e.g. 'lala_skylake' would be valid, but we want the base env in the line that fails)

```
(base) -bash-4.2$ source bin/activate_gpu_env lala
Could not find conda environment: lala
You can list all discoverable environments with `conda info --envs`.
```

